### PR TITLE
Better management of volatiles

### DIFF
--- a/koala/ExcelCompiler.py
+++ b/koala/ExcelCompiler.py
@@ -33,7 +33,7 @@ class ExcelCompiler(object):
         # Parse named_range { name (ExampleName) -> address (Sheet!A1:A10)}
         self.named_ranges = read_named_ranges(archive)
         self.Range = RangeFactory(self.cells)
-        self.volatile_ranges = set()
+        self.volatiles = set()
         self.debug = debug
 
     def clean_volatile(self):
@@ -42,7 +42,7 @@ class ExcelCompiler(object):
         cleaned_cells, cleaned_ranged_names = sp.clean_volatile()
         self.cells = cleaned_cells
         self.named_ranges = cleaned_ranged_names
-        self.volatile_ranges = []
+        self.volatiles = set()
             
     def gen_graph(self, outputs = [], inputs = []):
         print '___### Generating Graph ###___'
@@ -63,8 +63,7 @@ class ExcelCompiler(object):
                     if 'OFFSET' in reference or 'INDEX' in reference:
                         start_end = prepare_volatile(reference, self.named_ranges)
                         rng = self.Range(start_end)
-
-                        self.volatile_ranges.add(rng.name)
+                        self.volatiles.add(rng.name)
                     else:
                         rng = self.Range(reference)
 
@@ -136,4 +135,4 @@ class ExcelCompiler(object):
         # undirected = networkx.Graph(G)
         # print "Number of connected components %s", str(number_connected_components(undirected))
 
-        return Spreadsheet(G, cellmap, self.named_ranges, volatile_ranges = self.volatile_ranges, outputs = outputs, inputs = inputs, debug = self.debug)
+        return Spreadsheet(G, cellmap, self.named_ranges, volatiles = self.volatiles, outputs = outputs, inputs = inputs, debug = self.debug)

--- a/koala/ExcelCompiler.py
+++ b/koala/ExcelCompiler.py
@@ -63,7 +63,7 @@ class ExcelCompiler(object):
                     if 'OFFSET' in reference or 'INDEX' in reference:
                         start_end = prepare_volatile(reference, self.named_ranges)
                         rng = self.Range(start_end)
-                        self.volatiles.add(rng.name)
+                        self.volatiles.add(o)
                     else:
                         rng = self.Range(reference)
 
@@ -74,6 +74,9 @@ class ExcelCompiler(object):
                     seeds.append(virtual_cell)
                 else:
                     # might need to be changed to actual self.cells Cell, not a copy
+                    if 'OFFSET' in reference or 'INDEX' in reference:
+                        self.volatiles.add(o)
+
                     value = self.cells[reference].value if reference in self.cells else None
                     virtual_cell = Cell(o, None, value = value, formula = reference, is_range = False, is_named_range = True)
                     seeds.append(virtual_cell)

--- a/koala/Range.py
+++ b/koala/Range.py
@@ -137,8 +137,6 @@ class RangeCore(dict):
         # dont allow messing with these params
         if type(reference) == list:
             self.__name = name
-        elif type(reference) == dict:
-            self.__name = ':'.join([str(reference["start"]), str(reference["end"])])
         elif not self.is_volatile: # when building volatiles, name shouldn't be updated, but in that case reference is not a dict
             self.__name = reference
         self.__origin = origin

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -248,8 +248,6 @@ class Spreadsheet(object):
         ### 3) evaluate all volatiles
         if with_cache:
             cache = {} # formula => new_formula
-
-        print 'len vol', len(all_volatiles)
         
         for formula, address, sheet in all_volatiles:
 

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -212,6 +212,7 @@ class Spreadsheet(object):
 
     def clean_volatile(self, with_cache = True):
         print '___### Cleaning Volatiles ###___'
+        # with_cache = False
 
         new_named_ranges = self.named_ranges.copy()
         new_cells = self.cellmap.copy()
@@ -248,7 +249,10 @@ class Spreadsheet(object):
         if with_cache:
             cache = {} # formula => new_formula
 
+        print 'len vol', len(all_volatiles)
+        
         for formula, address, sheet in all_volatiles:
+
             if with_cache and formula in cache:
                 # print 'Retrieving', cell["address"], cell["formula"], cache[cell["formula"]]
                 new_formula = cache[formula]
@@ -288,7 +292,7 @@ class Spreadsheet(object):
             else: 
                 old_cell = self.cellmap[address]
                 new_cells[address] = Cell(old_cell.address(), old_cell.sheet, value=old_cell.value, formula=new_formula, is_range = old_cell.is_range, is_named_range=old_cell.is_named_range, should_eval=old_cell.should_eval)
-        
+
         return new_cells, new_named_ranges
 
     def print_value_ast(self, ast,node,indent):
@@ -300,8 +304,7 @@ class Spreadsheet(object):
         results = []
         context = cell["sheet"]
 
-        if (node.token.tvalue == "INDEX" and node.parent(ast) is not None and node.parent(ast).tvalue == ':') or \
-            (node.token.tvalue == "OFFSET"):
+        if (node.token.tvalue == "INDEX" or node.token.tvalue == "OFFSET"):
             volatile_string = reverse_rpn(node, ast)
             expression = node.emit(ast, context=context)
 
@@ -315,7 +318,7 @@ class Spreadsheet(object):
             except Exception as e:
                 if self.debug:
                     print 'EXCEPTION raised in eval_volatiles: EXPR', expression, cell["address"]
-                raise Exception("Problem evalling: %s for %s, %s" % (e, cell["address"], expression)) 
+                raise Exception("Problem evalling: %s for %s, %s" % (e, cell["address"], expression))
 
             return {"formula":volatile_string, "value": volatile_value, "expression_type": expression_type}      
         else:

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -509,7 +509,6 @@ class Spreadsheet(object):
         for vol_range in self.volatiles: # reset all volatiles
             self.reset(self.cellmap[vol_range])
 
-
     def reset(self, cell):
         addr = cell.address()
         if cell.value is None and addr not in self.named_ranges: return

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -372,13 +372,11 @@ class Spreadsheet(object):
                 cell = todo.pop()
 
                 if cell not in done:
-                    if cell.formula:
-                        for volatile_name in self.volatile_to_remove:
-                            if volatile_name in cell.formula:
-                                all_volatiles.add((cell.formula, cell.address(), cell.sheet if cell.sheet is not None else None))
-                    
-                    for parent in self.G.predecessors_iter(cell): # climb up the tree
-                        todo.append(parent) 
+                    if cell.address() in self.volatiles:
+                        if cell.formula:
+                            all_volatiles.add((cell.formula, cell.address(), cell.sheet if cell.sheet is not None else None))
+                        else:
+                            raise Exception('Volatiles should always have a formula')
 
                     done.add(cell)
 

--- a/koala/ast/__init__.py
+++ b/koala/ast/__init__.py
@@ -495,7 +495,7 @@ def graph_from_seeds(seeds, cell_source):
         #     print logStep, "->", deps
         # else:
         #     print logStep, "done"
-        
+
         for dep in deps:
             dep_name = dep.tvalue.replace('$','')
 
@@ -523,10 +523,13 @@ def graph_from_seeds(seeds, cell_source):
                     rng = cell_source.Range(reference)
 
                     if dep_name in names:
-                        address = dep_name # already added to cell_source.volatiles
+                        address = dep_name 
                     else:
-                        address = '%s:%s' % (reference["start"], reference["end"])
-                        cell_source.volatiles.add(address)
+                        if c1.address() in names:
+                            address = c1.address() # virtual cell will be added again (already done in ExcelCompiler), optimization is needed
+                        else:
+                            address = '%s:%s' % (reference["start"], reference["end"])
+                            cell_source.volatiles.add(address)
                 else:
                     address = dep_name
                     rng = cell_source.Range(reference)
@@ -569,11 +572,10 @@ def graph_from_seeds(seeds, cell_source):
                         origins = [cell]
 
                     cell = origins[0]
-
+                    
                     if cell.formula is not None and ('OFFSET' in cell.formula or 'INDEX' in cell.formula):
                         cell_source.volatiles.add(cell.address())
                 else:
-                    # print 'DEP NAME not in cells'
                     virtual_cell = Cell(dep_name, None, value = None, formula = None, is_range = False, is_named_range = True )
                     origins = [virtual_cell]
 

--- a/koala/ast/__init__.py
+++ b/koala/ast/__init__.py
@@ -467,7 +467,7 @@ def graph_from_seeds(seeds, cell_source):
         c1.python_expression = pystr.replace('"', "'") # compilation is done later
         
         if 'OFFSET' in c1.formula or 'INDEX' in c1.formula:
-            if c1.address() not in cell_source.named_ranges: # volatiles names already treatedd in ExcelCompiler
+            if c1.address() not in cell_source.named_ranges: # volatiles names already treated in ExcelCompiler
                 cell_source.volatiles.add(c1.address())
 
         # get all the cells/ranges this formula refers to

--- a/koala/reader.py
+++ b/koala/reader.py
@@ -189,8 +189,8 @@ def read_cells(archive, ignore_sheets = [], ignore_hidden = False):
                 if cell['f'] is not None or cell['v'] is not None:
                     should_eval = 'always' if cell['f'] is not None and 'OFFSET' in cell['f'] else 'normal'
                     
-                    cleaned_formula = cell['f']
-                    # cleaned_formula = cell['f'].replace(" ", "") if cell['f'] is not None else None
+                    # cleaned_formula = cell['f']
+                    cleaned_formula = cell['f'].replace(", ", ",") if cell['f'] is not None else None
                     if "!" in cell_address:
                         cells[cell_address] = Cell(cell_address, sheet_name, value = cell['v'], formula = cleaned_formula, should_eval=should_eval)
                     else:

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -7,7 +7,6 @@ from networkx.readwrite import json_graph
 from networkx.algorithms import number_connected_components
 from networkx.drawing.nx_pydot import write_dot
 from networkx.drawing.nx_pylab import draw, draw_circular
-import marshal
 
 from koala.Cell import Cell
 from koala.Range import RangeCore, RangeFactory
@@ -15,11 +14,9 @@ from koala.Range import RangeCore, RangeFactory
 SEP = ";;"
 
 ########### based on custom format #################
-def dump(self, fname, marshal = False):
+def dump(self, fname):
     outfile = gzip.GzipFile(fname, 'w')
 
-    if marshal:
-        outfile2 = open(fname + "_marshal", 'wb')
 
     # write simple cells first
     simple_cells = filter(lambda cell: cell.is_range == False, self.cellmap.values())
@@ -71,9 +68,7 @@ def dump(self, fname, marshal = False):
             outfile.write(cell.range.name + "\n")
 
         outfile.write("====" + "\n")
-
-    if marshal:
-        marshal.dump(compiled_expressions, outfile2)
+        outfile.write("====" + "\n")
     
     # writing the edges
     outfile.write("edges" + "\n")
@@ -125,12 +120,7 @@ def load(fname):
     inputs = None
     named_ranges = {}
     infile = gzip.GzipFile(fname, 'r')
-    try:
-        infile2 = open(fname + "_marshal", "rb")
-        compiled_expressions = marshal.load(infile2)
-        marshaled_file = True
-    except:
-        marshaled_file = False
+
     for line in infile.read().splitlines():
 
         if line == "====":
@@ -189,11 +179,8 @@ def load(fname):
                     if 'OFFSET' in formula or 'INDEX' in formula:
                         volatiles.add(address)
 
-                    if marshaled_file:
-                        ce = compiled_expressions[address]
-                        cell.compiled_expression = ce
-                    else:
-                        cell.compile()               
+
+                    cell.compile()               
                 nodes.append(cell)
         elif mode == "edges":
             source, target = line.split(SEP)

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -120,7 +120,7 @@ def load(fname):
     mode = "node0"
     nodes = []
     edges = []
-    volatile_ranges = set()
+    volatiles = set()
     outputs = None
     inputs = None
     named_ranges = {}
@@ -171,7 +171,7 @@ def load(fname):
                 vv = Range(reference)
 
                 if is_volatile:
-                    volatile_ranges.add(vv.name)
+                    volatiles.add(vv.name)
 
                 cell = Cell(address, None, vv, formula, is_range, is_named_range, should_eval)
                 cell.python_expression = python_expression
@@ -180,8 +180,12 @@ def load(fname):
                 value = to_bool(to_float(line))
                 
                 cell = Cell(address, None, value, formula, is_range, is_named_range, should_eval)
+                
                 cell.python_expression = python_expression
                 if formula:
+                    if 'OFFSET' in formula or 'INDEX' in formula:
+                        volatiles.add(address)
+
                     if marshaled_file:
                         ce = compiled_expressions[address]
                         cell.compiled_expression = ce
@@ -203,7 +207,7 @@ def load(fname):
 
     print "Graph loading done, %s nodes, %s edges, %s cellmap entries" % (len(G.nodes()),len(G.edges()),len(cellmap))
 
-    return (G, cellmap, named_ranges, volatile_ranges, outputs, inputs)
+    return (G, cellmap, named_ranges, volatiles, outputs, inputs)
 
 ########### based on json #################
 def dump_json(self, fname):

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -171,7 +171,10 @@ def load(fname):
                 vv = Range(reference)
 
                 if is_volatile:
-                    volatiles.add(vv.name)
+                    if not is_named_range:
+                        address = vv.name
+
+                    volatiles.add(address)
 
                 cell = Cell(address, None, vv, formula, is_range, is_named_range, should_eval)
                 cell.python_expression = python_expression


### PR DESCRIPTION
This PR fixes bugs related to Volatiles Ranges.

Now, all volatiles (Ranges or not) are stored in a `Spreadsheet.volatiles` set (before named `Spreadsheet.volatiles_ranges`). This means that even Cells holding a volatile (INDEX of OFFSET) in its formula will be stored as volatile.
Plus, what is stored within this set is always the address, even for Volatile Ranges (before, the `reference` `dict` was stored, with its `start`/`end` python formula).

These changes allow:
- no more Volatile Ranges duplicates in the cellmap
- simplification of the `Spreadsheet.detect_alive()` function, which scans effectively all instances in `Spreadsheet.volatiles()`
- automatic reset of all volatiles on `Spreadsheet.set_value()`, not just Ranges

A legacy bug concerning the handling of INDEX in `Spreadsheet.clean_volatiles()` was also fixed.

Fixes #57, #92, #93
