### PR TITLE
[bug] unicode type is also checked when tokenizing, fixes #106

### DIFF
--- a/koala/ast/__init__.py
+++ b/koala/ast/__init__.py
@@ -115,7 +115,8 @@ def shunting_yard(expression, named_ranges, ref = None, tokenize_range = False):
         for index, token in enumerate(tokens):
             new_tokens.append(token)
 
-            if type(token.tvalue) == str:
+            if type(token.tvalue) == str or type(token.tvalue) == unicode:
+
                 if token.tvalue.startswith(':'): # example -> :OFFSET( or simply :A10
                     depth = 0
                     expr = ''

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -63,7 +63,7 @@ def dump(self, fname):
         parse_cell_info(cell)
 
         if cell.range.is_pointer:
-            outfile.write(json.dumps((cell.range.reference) + u"\n").encode('utf-8'))
+            outfile.write((json.dumps(cell.range.reference) + u"\n").encode('utf-8'))
         else:
             outfile.write((cell.range.name + u"\n").encode('utf-8'))
 


### PR DESCRIPTION
This a bug fix linked to #106.
This reactivates the idea to properly address our "`unicode` or `string` problem", which we don't really.
We should handle all `strings` as `unicodes` by default.