### PR TITLE
added functions.json to MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include koala/functions.json


### PR DESCRIPTION
The koala2 package hosted in pypi (https://pypi.python.org/pypi/koala2/0.0.14) appears to be missing the functions.json

So I've added this here to include that file during `setup.py build sdist`.

Not sure if you have a preferred way of including it over this? but it'd be good to update the packages hosted pypi with a working copy as currently it fails to import cause it's missing this file.