### PR TITLE
added requirements to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include koala/functions.json
+include requirements.txt


### PR DESCRIPTION
Hi again, thanks for the merging #117! Apologies for not realising this in that PR but the `requirements.txt` also needs to be included for the install from pip to work

Did some checking and i _think_ that is all that'll be required to make the pip install work :crossed_fingers: 