### PR TITLE
Add error information string to calculation history.

### DIFF
--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -705,7 +705,10 @@ class Spreadsheet(object):
 
                     self.history[cell.address()]['new'] = str(cell.value)
                 else:
-                    self.history[cell.address()] = {'new': str(cell.value)}
+                    if isinstance(cell.value, ExcelError):
+                        self.history[cell.address()] = {'new': str(cell.value), 'error': str(cell.value.info)}
+                    else:
+                        self.history[cell.address()] = {'new': str(cell.value)}
 
         except Exception as e:
             if str(e).startswith("Problem evalling"):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     setup(
         name="koala2",
 
-        version="0.0.24",
+        version="0.0.25",
 
         author="Ants, open innovation lab",
         author_email="contact@weareants.fr",


### PR DESCRIPTION
Helpful te debug math problems inside another function.

With current behaviour value will be `#N\A` without additional information.