### PR TITLE
Improve performance

### DIFF
--- a/koala/Cell.py
+++ b/koala/Cell.py
@@ -66,6 +66,8 @@ class Cell(object):
         self.__compiled_expression = None
         self.__is_range = is_range
 
+        self.is_range = self.__is_range
+
         # every cell has a unique id
         self.__id = Cell.next_id()
 
@@ -100,10 +102,6 @@ class Cell(object):
     @property
     def is_named_range(self):
         return self.__named_range is not None
-
-    @property
-    def is_range(self):
-        return self.__is_range
 
     @property
     def sheet(self):

--- a/koala/Cell.py
+++ b/koala/Cell.py
@@ -67,6 +67,11 @@ class Cell(object):
         self.__is_range = is_range
 
         self.is_range = self.__is_range
+        self.is_named_range = self.__named_range is not None
+
+        self.__absolute_address = (
+            "%s!%s%s" % (self.__sheet, self.__col, self.__row))
+        self.__address = "%s%s" % (self.__col, self.__row)
 
         # every cell has a unique id
         self.__id = Cell.next_id()
@@ -98,10 +103,6 @@ class Cell(object):
             self.__value = new_range
         else:
             raise Exception('Setting a range as non-range Cell %s value' % self.address())
-
-    @property
-    def is_named_range(self):
-        return self.__named_range is not None
 
     @property
     def sheet(self):
@@ -155,12 +156,12 @@ class Cell(object):
         return self.address().replace('!','_').replace(' ','_')
 
     def address(self, absolute=True):
-        if self.__named_range is not None:
+        if self.is_named_range:
             return self.__named_range
         elif absolute:
-            return "%s!%s%s" % (self.__sheet,self.__col,self.__row)
+            return self.__absolute_address
         else:
-            return "%s%s" % (self.__col,self.__row)
+            return self.__address
 
     def address_parts(self):
         return (self.__sheet,self.__col,self.__row,self.__col_idx)

--- a/koala/ExcelCompiler.py
+++ b/koala/ExcelCompiler.py
@@ -19,7 +19,7 @@ class ExcelCompiler(object):
     """
 
     def __init__(self, file, ignore_sheets = [], ignore_hidden = False, debug = False):
-        print("___### Initializing Excel Compiler ###___")
+        # print("___### Initializing Excel Compiler ###___")
 
         file_name = os.path.abspath(file)
         # Decompose subfiles structure in zip file
@@ -41,7 +41,7 @@ class ExcelCompiler(object):
         self.pointers = set()
 
     def gen_graph(self, outputs = [], inputs = []):
-        print('___### Generating Graph ###___')
+        # print('___### Generating Graph ###___')
 
         if len(outputs) == 0:
             preseeds = set(list(flatten(self.cells.keys())) + list(self.named_ranges.keys())) # to have unicity
@@ -86,7 +86,7 @@ class ExcelCompiler(object):
                     seeds.append(self.cells[o])
 
         seeds = set(seeds)
-        print("Seeds %s cells" % len(seeds))
+        # print("Seeds %s cells" % len(seeds))
         outputs = set(preseeds) if len(outputs) > 0 else [] # seeds and outputs are the same when you don't specify outputs
 
         cellmap, G = graph_from_seeds(seeds, self)
@@ -128,7 +128,7 @@ class ExcelCompiler(object):
             inputs = set(inputs)
 
 
-        print("Graph construction done, %s nodes, %s edges, %s cellmap entries" % (len(G.nodes()),len(G.edges()),len(cellmap)))
+        # print("Graph construction done, %s nodes, %s edges, %s cellmap entries" % (len(G.nodes()),len(G.edges()),len(cellmap)))
 
         # undirected = networkx.Graph(G)
         # print "Number of connected components %s", str(number_connected_components(undirected))

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -453,7 +453,6 @@ class Spreadsheet(object):
         return Spreadsheet.from_dict(data)
 
     def set_value(self, address, val):
-
         self.reset_buffer = set()
 
         try:
@@ -464,31 +463,28 @@ class Spreadsheet(object):
             self.fix_cell(address)
 
             # case where the address refers to a range
-            if self.cellmap[address].is_range:
+            if cell.is_range:
                 cells_to_set = []
-                # for a in self.cellmap[address].range.addresses:
-                    # if a in self.cellmap:
-                    #     cells_to_set.append(self.cellmap[a])
-                    #     self.fix_cell(a)
 
-                if type(val) != list:
-                    val = [val]*len(cells_to_set)
+                if not isinstance(val, list):
+                    val = [val] * len(cells_to_set)
 
                 self.reset(cell)
                 cell.range.values = val
 
             # case where the address refers to a single value
             else:
-                if address in self.named_ranges: # if the cell is a named range, we need to update and fix the reference cell
+                if address in self.named_ranges:  # if the cell is a named range, we need to update and fix the reference cell
                     ref_address = self.named_ranges[address]
 
                     if ref_address in self.cellmap:
                         ref_cell = self.cellmap[ref_address]
                     else:
-                        ref_cell = Cell(ref_address, None, value = val, formula = None, is_range = False, is_named_range = False )
+                        ref_cell = Cell(
+                            ref_address, None, value=val,
+                            formula=None, is_range=False, is_named_range=False)
                         self.add_cell(ref_cell)
 
-                    # self.fix_cell(ref_address)
                     ref_cell.value = val
 
                 if cell.value != val:
@@ -502,7 +498,7 @@ class Spreadsheet(object):
             for vol in self.pointers_to_reset:  # reset all pointers
                 self.reset(self.cellmap[vol])
         except KeyError:
-            raise Exception('Cell %s not in cellmap' % address) 
+            raise Exception('Cell %s not in cellmap' % address)
 
     def reset(self, cell):
         addr = cell.address()

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -456,57 +456,58 @@ class Spreadsheet(object):
 
         self.reset_buffer = set()
 
-        if address not in self.cellmap:
-            raise Exception("Address not present in graph.")
-            
-        address = address.replace('$','')
-        cell = self.cellmap[address]
+        try:
+            address = address.replace('$', '')
+            cell = self.cellmap[address]
 
-        # when you set a value on cell, its should_eval flag is set to 'never' so its formula is not used until set free again => sp.activate_formula()
-        self.fix_cell(address)
+            # when you set a value on cell, its should_eval flag is set to 'never' so its formula is not used until set free again => sp.activate_formula()
+            self.fix_cell(address)
 
-        # case where the address refers to a range
-        if self.cellmap[address].is_range:
-            cells_to_set = []
-            # for a in self.cellmap[address].range.addresses:
-                # if a in self.cellmap:
-                #     cells_to_set.append(self.cellmap[a])
-                #     self.fix_cell(a)
+            # case where the address refers to a range
+            if self.cellmap[address].is_range:
+                cells_to_set = []
+                # for a in self.cellmap[address].range.addresses:
+                    # if a in self.cellmap:
+                    #     cells_to_set.append(self.cellmap[a])
+                    #     self.fix_cell(a)
 
-            if type(val) != list:
-                val = [val]*len(cells_to_set)
+                if type(val) != list:
+                    val = [val]*len(cells_to_set)
 
-            self.reset(cell)
-            cell.range.values = val
-
-        # case where the address refers to a single value
-        else:
-            if address in self.named_ranges: # if the cell is a named range, we need to update and fix the reference cell
-                ref_address = self.named_ranges[address]
-
-                if ref_address in self.cellmap:
-                    ref_cell = self.cellmap[ref_address]
-                else:
-                    ref_cell = Cell(ref_address, None, value = val, formula = None, is_range = False, is_named_range = False )
-                    self.add_cell(ref_cell)
-
-                # self.fix_cell(ref_address)
-                ref_cell.value = val
-
-            if cell.value != val:
-                if cell.value is None:
-                    cell.value = 'notNone' # hack to avoid the direct return in reset() when value is None
-                # reset the node + its dependencies
                 self.reset(cell)
-                # set the value
-                cell.value = val
+                cell.range.values = val
 
-        for vol in self.pointers_to_reset: # reset all pointers
-            self.reset(self.cellmap[vol])
+            # case where the address refers to a single value
+            else:
+                if address in self.named_ranges: # if the cell is a named range, we need to update and fix the reference cell
+                    ref_address = self.named_ranges[address]
+
+                    if ref_address in self.cellmap:
+                        ref_cell = self.cellmap[ref_address]
+                    else:
+                        ref_cell = Cell(ref_address, None, value = val, formula = None, is_range = False, is_named_range = False )
+                        self.add_cell(ref_cell)
+
+                    # self.fix_cell(ref_address)
+                    ref_cell.value = val
+
+                if cell.value != val:
+                    if cell.value is None:
+                        cell.value = 'notNone'  # hack to avoid the direct return in reset() when value is None
+                    # reset the node + its dependencies
+                    self.reset(cell)
+                    # set the value
+                    cell.value = val
+
+            for vol in self.pointers_to_reset:  # reset all pointers
+                self.reset(self.cellmap[vol])
+        except KeyError:
+            raise Exception('Cell %s not in cellmap' % address) 
 
     def reset(self, cell):
         addr = cell.address()
-        if cell.value is None and addr not in self.named_ranges: return
+        if cell.value is None and addr not in self.named_ranges:
+            return
 
         # update cells
         if cell.should_eval != 'never':
@@ -521,15 +522,15 @@ class Spreadsheet(object):
                 self.reset(child)
 
     def fix_cell(self, address):
-        if address in self.cellmap:
+        try:
             if address not in self.fixed_cells:
                 cell = self.cellmap[address]
                 self.fixed_cells[address] = cell.should_eval
                 cell.should_eval = 'never'
-        else:
+        except KeyError:
             raise Exception('Cell %s not in cellmap' % address)
 
-    def free_cell(self, address = None):
+    def free_cell(self, address=None):
         if address is None:
             for addr in self.fixed_cells:
                 cell = self.cellmap[addr]
@@ -541,17 +542,18 @@ class Spreadsheet(object):
                 cell.should_eval = self.fixed_cells[addr]
             self.fixed_cells = {}
 
-        elif address in self.cellmap:
-            cell = self.cellmap[address]
-
-            cell.should_eval = 'always' # this is to be able to correctly reinitiliaze the value
-            if cell.python_expression is not None:
-                self.eval_ref(address)
-
-            cell.should_eval = self.fixed_cells[address]
-            self.fixed_cells.pop(address, None)
         else:
-            raise Exception('Cell %s not in cellmap' % address)
+            try:
+                cell = self.cellmap[address]
+
+                cell.should_eval = 'always' # this is to be able to correctly reinitiliaze the value
+                if cell.python_expression is not None:
+                    self.eval_ref(address)
+
+                cell.should_eval = self.fixed_cells[address]
+                self.fixed_cells.pop(address, None)
+            except KeyError:
+                raise Exception('Cell %s not in cellmap' % address)
 
     def print_value_tree(self,addr,indent):
         cell = self.cellmap[addr]

--- a/koala/reader.py
+++ b/koala/reader.py
@@ -104,7 +104,7 @@ def read_named_ranges(archive):
 def read_cells(archive, ignore_sheets = [], ignore_hidden = False):
     global debug
 
-    print('___### Reading Cells from XLSX ###___')
+    # print('___### Reading Cells from XLSX ###___')
 
     cells = {}
 
@@ -158,19 +158,22 @@ def read_cells(archive, ignore_sheets = [], ignore_hidden = False):
 
             if not skip:
                 cell = {'a': '%s!%s' % (sheet_name, cell_address), 'f': None, 'v': None}
-                if debug: print('Cell', cell['a'])
+                if debug:
+                    print('Cell', cell['a'])
                 for child in c:
                     child_data_type = child.get('t', 'n') # if no type assigned, assign 'number'
 
                     if child.tag == '{%s}f' % SHEET_MAIN_NS :
                         if 'ref' in child.attrib: # the first cell of a shared formula has a 'ref' attribute
-                            if debug: print('*** Found definition of shared formula ***', child.text, child.attrib['ref'])
+                            if debug:
+                                print('*** Found definition of shared formula ***', child.text, child.attrib['ref'])
                             if "si" in child.attrib:
                                 function_map[child.attrib['si']] = (child.attrib['ref'], Translator(str('=' + child.text), cell_address)) # translator of openpyxl needs a unicode argument that starts with '='
                             # else:
                             #     print "Encountered cell with ref but not si: ", sheet_name, child.attrib['ref']
                         if child_data_type == 'shared':
-                            if debug: print('*** Found child %s of shared formula %s ***' % (cell_address, child.attrib['si']))
+                            if debug:
+                                print('*** Found child %s of shared formula %s ***' % (cell_address, child.attrib['si']))
 
                             ref = function_map[child.attrib['si']][0]
                             formula = function_map[child.attrib['si']][1]
@@ -212,15 +215,15 @@ def read_cells(archive, ignore_sheets = [], ignore_hidden = False):
                     else:
                         cells[sheet_name + "!" + cell_address] = Cell(cell_address, sheet_name, value = cell['v'], formula = cleaned_formula, should_eval=should_eval)
 
-        if nb_hidden > 0:
-            print('Ignored %i hidden cells in sheet %s' % (nb_hidden, sheet_name))
+        # if nb_hidden > 0:
+            # print('Ignored %i hidden cells in sheet %s' % (nb_hidden, sheet_name))
 
-    print('Nb of different functions %i' % len(functions))
-    print(functions)
+    # print('Nb of different functions %i' % len(functions))
+    # print(functions)
 
-    for f in functions:
-        if f not in existing:
-            print('== Missing function: %s' % f)
+    # for f in functions:
+    #     if f not in existing:
+    #         print('== Missing function: %s' % f)
 
     return cells
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     setup(
         name="koala2",
 
-        version="0.0.25",
+        version="0.0.26",
 
         author="Ants, open innovation lab",
         author_email="contact@weareants.fr",


### PR DESCRIPTION
Hi, @vallettea !

To improve performance I've made following changes:
1. remove print() statements during file parse. I suggest to use logging module further if debug output is required.
2. apply EAFP principle: replaced some if/else with try/catch when else branch is supposed to be rare. This principle has been applied to checks `if address not in self.cellmap`
3. replace some frequently accessed Cell properties with direct access to attributes (we do not loose time on function call). This has been applied when there is no @property.setter
4. evaluate string for Cell.address property only once and do not loose time on evaluating string on each property access
5. minor: remove unnecessary dict lookup (when we have already made the same lookup and know the result)
6. replace type() with isinstance()

These changes gave approx. 10% boost both for parsing excel file (due to no print statements) and for setting values + evaluating. I've tested on 1000 evaluation of 10 000 excel files.

PS: I've increased the version number too

Thanks and regards