### PR TITLE
Ensure dump/load functions work correctly under Python 3

### DIFF
--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -749,7 +749,7 @@ class Spreadsheet(object):
 
         links = []
         for el in data['links']:
-            link = {key: cell.address() for key, cell in el.iteritems()}
+            link = {key: cell.address() for key, cell in el.items()}
             links.append(link)
 
         data["nodes"] = nodes

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -198,7 +198,7 @@ def dump_json(self, fname):
     data = self.asdict()
 
     with gzip.GzipFile(fname, 'w') as outfile:
-        outfile.write(json.dumps(data))
+        outfile.write(json.dumps(data).encode('utf-8'))
 
 
 def load_json(fname):
@@ -206,9 +206,9 @@ def load_json(fname):
     def _decode_list(data):
         rv = []
         for item in data:
-            if isinstance(item, unicode):
+            if isinstance(item, unicode) and unicode != str:
                 item = item.encode('utf-8')
-            elif isinstance(item, list):
+            elif isinstance(item, list) and unicode != str:
                 item = _decode_list(item)
             elif isinstance(item, dict):
                 item = _decode_dict(item)
@@ -218,9 +218,9 @@ def load_json(fname):
     def _decode_dict(data):
         rv = {}
         for key, value in data.items():
-            if isinstance(key, unicode):
+            if isinstance(key, unicode) and unicode != str:
                 key = key.encode('utf-8')
-            if isinstance(value, unicode):
+            if isinstance(value, unicode) and unicode != str:
                 value = value.encode('utf-8')
             elif isinstance(value, list):
                 value = _decode_list(value)
@@ -230,7 +230,7 @@ def load_json(fname):
         return rv
 
     with gzip.GzipFile(fname, 'r') as infile:
-        data = json.loads(infile.read(), object_hook=_decode_dict)
+        data = json.loads(infile.read().decode('utf-8'), object_hook=_decode_dict)
 
     return data
 

--- a/tests/excel/test_excel.py
+++ b/tests/excel/test_excel.py
@@ -7,7 +7,7 @@ path = os.path.join(dir, '../../')
 sys.path.insert(0, path)
 
 from koala.reader import read_archive, read_cells
-from koala import ExcelCompiler
+from koala import ExcelCompiler, Spreadsheet
 
 
 # # This fails, needs to be adapted
@@ -53,6 +53,101 @@ class Test_NamedRanges(unittest.TestCase):
     def test_after_set_value(self):
         self.graph.set_value('INPUT', 2025)
         self.assertTrue(self.graph.evaluate('INPUT') == 2025 and self.graph.evaluate('Sheet1!A1') == 2025 and self.graph.evaluate('RESULT') == 2211)
+
+
+class Test_DumpDict(unittest.TestCase):
+
+    def setUp(self):
+        c = ExcelCompiler("./tests/files/NamedRanges.xlsx", ignore_sheets=['IHS'])
+        self.graph = c.gen_graph()
+        sys.setrecursionlimit(10000)
+
+    def test_no_set_value(self):
+        graph = self.graph
+        self.assertTrue(graph.evaluate('INPUT') == 1)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 1)
+        self.assertTrue(graph.evaluate('RESULT') == 187)
+
+    def test_set_value(self):
+        # Clone object
+        data = self.graph.asdict()
+        graph = Spreadsheet.from_dict(data)
+
+        # Set value and check result in clone.
+        graph.set_value('INPUT', 2025)
+        self.assertTrue(graph.evaluate('INPUT') == 2025)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 2025)
+        # self.assertTrue(graph.evaluate('RESULT') == 2211)
+
+        # Check original not changed.
+        graph = self.graph
+        self.assertTrue(graph.evaluate('INPUT') == 1)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 1)
+        self.assertTrue(graph.evaluate('RESULT') == 187)
+
+
+class Test_Dump(unittest.TestCase):
+
+
+    def setUp(self):
+        c = ExcelCompiler("./tests/files/NamedRanges.xlsx", ignore_sheets = ['IHS'])
+        self.graph = c.gen_graph()
+        sys.setrecursionlimit(10000)
+
+    def test_no_set_value(self):
+        graph = self.graph
+        self.assertTrue(graph.evaluate('INPUT') == 1)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 1)
+        self.assertTrue(graph.evaluate('RESULT') == 187)
+
+    def test_set_value(self):
+        # Clone object
+        self.graph.dump("dump.txt.gz")
+        graph = Spreadsheet.load("dump.txt.gz")
+
+        # Set value and check result in clone.
+        graph.set_value('INPUT', 2025)
+        self.assertTrue(graph.evaluate('INPUT') == 2025)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 2025)
+        # self.assertTrue(graph.evaluate('RESULT') == 2211)
+
+        # Check original not changed.
+        graph = self.graph
+        self.assertTrue(graph.evaluate('INPUT') == 1)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 1)
+        self.assertTrue(graph.evaluate('RESULT') == 187)
+
+
+class Test_DumpJson(unittest.TestCase):
+
+
+    def setUp(self):
+        c = ExcelCompiler("./tests/files/NamedRanges.xlsx", ignore_sheets = ['IHS'])
+        self.graph = c.gen_graph()
+        sys.setrecursionlimit(10000)
+
+    def test_no_set_value(self):
+        graph = self.graph
+        self.assertTrue(graph.evaluate('INPUT') == 1)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 1)
+        self.assertTrue(graph.evaluate('RESULT') == 187)
+
+    def test_set_value(self):
+        # Clone object
+        self.graph.dump_json("dump.txt.gz")
+        graph = Spreadsheet.load_json("dump.txt.gz")
+
+        # Set value and check result in clone.
+        graph.set_value('INPUT', 2025)
+        self.assertTrue(graph.evaluate('INPUT') == 2025)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 2025)
+        # self.assertTrue(graph.evaluate('RESULT') == 2211)
+
+        # Check original not changed.
+        graph = self.graph
+        self.assertTrue(graph.evaluate('INPUT') == 1)
+        self.assertTrue(graph.evaluate('Sheet1!A1') == 1)
+        self.assertTrue(graph.evaluate('RESULT') == 187)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think there might still be problems actually. Still trying to chase an error that I get after dumping and loading a spreadsheet using dump/load.

Attempting to use this as a solution for the fact `ExcelCompiler` followed by `gen_graph` is slow, and we really need a clean sheet for each new calculation. Around 10 seconds  to load this sheet. However I note `from_dict` is even slower. Takes minutes.

In comparison dump followed by load takes about 2 seconds.

I have not tested these changes under Python 2. Hoping this will happen automatically.