### PR TITLE
Do not install_requires specific versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,12 @@ if __name__ == '__main__':
 
         long_description=open("README.md").read(),
 
-        install_requires=open('requirements.txt').readlines(),
+        install_requires=[
+            'networkx >= 2.1',
+            'openpyxl >= 2.5.3',
+            'numpy >= 1.14.2',
+            'Cython >= 0.28.2',
+            'lxml >= 4.1.1',
+            'six >= 1.11.0',
+        ]
     )


### PR DESCRIPTION
We should not be requiring specific versions in setup.py. To do so
makes it difficult to upgrade a dependency in an application because it
then cause pip to complain that other dependencies require the old
version. It many cases the new version will work fine too - if not then
this is a bug that should get fixed rather then limiting the versions.

For more information see
https://packaging.python.org/discussions/install-requires-vs-requirements/