### PR TITLE
Support for col:col ranges

### DIFF
--- a/koala/utils.py
+++ b/koala/utils.py
@@ -124,10 +124,17 @@ def resolve_range(rng, should_flatten = False, sheet=''):
         return resolve_range_cache[key]
     else:
         if not is_range(rng):  return ([sheet + rng],1,1)
-
         # single cell, no range
-        sh, start_col, start_row = split_address(start)
-        sh, end_col, end_row = split_address(end)
+        if start.isdigit() and end.isdigit():
+			# This copes with 5:5 style ranges
+            start_col = "A"
+            start_row = start
+            end_col = "XFD"
+            end_row = end
+        else:    
+            sh, start_col, start_row = split_address(start)
+            sh, end_col, end_row = split_address(end)
+
         start_col_idx = col2num(start_col)
         end_col_idx = col2num(end_col);
 


### PR DESCRIPTION
I ran into a similar issue as described in https://github.com/anthill/koala/issues/152
I took the maximum possible column range (16 384 columns) which is not the most efficient solution.
A more efficient way to implement this is to limit the number of columns, for instance by the used range. But this should be done in a coherent way over the sheets.