### PR TITLE
Fix match for mixed strings and numbers

### DIFF
--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -407,6 +407,13 @@ def match(lookup_value, lookup_range, match_type=1): # Excel reference: https://
             value = 0
 
         return value;
+    def type_convert_float(value):
+        if is_number(value):
+            value = float(value)
+        else:
+            value = None
+
+        return value
 
     lookup_value = type_convert(lookup_value)
 
@@ -432,7 +439,12 @@ def match(lookup_value, lookup_range, match_type=1): # Excel reference: https://
     elif match_type == 0:
         # No string wildcard
         try:
-            return [type_convert(x) for x in range_values].index(lookup_value) + 1
+            if is_number(lookup_value):
+                lookup_value = float(lookup_value)
+                output = [type_convert_float(x) for x in range_values].index(lookup_value) + 1
+            else:
+                output = [str(x).lower() for x in range_values].index(lookup_value) + 1
+            return output
         except:
             return ExcelError('#VALUE!', '%s not found' % lookup_value)
 

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -633,6 +633,17 @@ class Test_Match(unittest.TestCase):
         # Value is found
         self.assertEqual(match('a', range, 0), 2)
 
+    def test_mixed_string_floats_in_exact_mode(self):
+        range = Range('A1:A4', ['aab', '3.0', 'rars', 3.3])
+        # Value is found
+        self.assertEqual(match('aab', range, 0), 1)
+        self.assertEqual(match('3.0', range, 0), 2)
+        self.assertEqual(match(3, range, 0), 2)
+        self.assertEqual(match(3.0, range, 0), 2)
+        self.assertEqual(match('rars', range, 0), 3)
+        self.assertEqual(match('3.3', range, 0), 4)
+        self.assertEqual(match(3.3, range, 0), 4)
+
     @unittest.skip('This test fails.')
     def test_string_in_exact_mode_not_found(self):
         range = Range('A1:A3', ['aab', 'a', 'rars'])


### PR DESCRIPTION
Match did not match very well when the ranges and lookup values weren't all strings or floats. This pull request should improve that behaviour.