### PR TITLE
Make XIRR, XNPV, NPV and IRR more robust

### DIFF
--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -960,6 +960,9 @@ def irr(values, guess = None):
     if isinstance(values, Range):
         values = values.values
 
+    if is_not_number_input(values):
+        return numeric_error(values, 'values')
+
     if guess is not None and guess != 0:
         raise ValueError('guess value for excellib.irr() is %s and not 0' % guess)
     else:

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -984,6 +984,12 @@ def xirr(values, dates, guess=0):
     if isinstance(dates, Range):
         dates = dates.values
 
+    if is_not_number_input(values):
+        return numeric_error(values, 'values')
+
+    if is_not_number_input(dates):
+        return numeric_error(dates, 'dates')
+
     if guess is not None and guess != 0:
         raise ValueError('guess value for excellib.irr() is %s and not 0' % guess)
     else:
@@ -1140,6 +1146,15 @@ def xnpv(rate, values, dates, lim_rate = True):  # Excel reference: https://supp
 
     if isinstance(dates, Range):
         dates = dates.values
+
+    if is_not_number_input(rate):
+        return numeric_error(rate, 'rate')
+
+    if is_not_number_input(values):
+        return numeric_error(values, 'values')
+
+    if is_not_number_input(dates):
+        return numeric_error(dates, 'dates')
 
     if len(values) != len(dates):
         return ExcelError('#NUM!', '`values` range must be the same length as `dates` range in XNPV, %s != %s' % (len(values), len(dates)))

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -8,6 +8,7 @@ Python equivalents of various excel functions
 
 from __future__ import absolute_import, division
 
+import itertools
 import numpy as np
 import scipy.optimize
 import datetime
@@ -95,7 +96,6 @@ IND_FUN = [
     "OFFSET",
     "SUMPRODUCT",
     "IFERROR",
-    "IRR",
     "XIRR",
     "VLOOKUP",
     "VDB",
@@ -396,15 +396,19 @@ def linest(*args, **kwargs): # Excel reference: https://support.office.com/en-us
     return coefs
 
 
-# NEEDS TEST
-def npv(*args): # Excel reference: https://support.office.com/en-us/article/NPV-function-8672cb67-2576-4d07-b67b-ac28acf2a568
-    discount_rate = args[0]
-    cashflow = args[1]
+def npv(rate, *values): # Excel reference: https://support.office.com/en-us/article/NPV-function-8672cb67-2576-4d07-b67b-ac28acf2a568
+    cashflow = list(flatten_list(list(values)))
+
+    if is_not_number_input(rate):
+        return numeric_error(rate, 'rate')
+
+    if is_not_number_input(cashflow):
+        return numeric_error(cashflow, 'values')
 
     if isinstance(cashflow, Range):
         cashflow = cashflow.values
 
-    return sum([float(x)*(1+discount_rate)**-(i+1) for (i,x) in enumerate(cashflow)])
+    return sum([float(x)*(1+rate)**-(i+1) for (i,x) in enumerate(cashflow)])
 
 
 def rows(array):

--- a/koala/utils.py
+++ b/koala/utils.py
@@ -355,6 +355,21 @@ def uniqueify(seq):
     seen_add = seen.add
     return [ x for x in seq if x not in seen and not seen_add(x)]
 
+
+def is_not_number_input(input_value):
+    if isinstance(input_value, list):
+        return not all([is_number(i) for i in input_value])
+    else:
+        return not is_number(input_value)
+
+
+def numeric_error(input_value, input_name):
+    if isinstance(input_value, ExcelError):
+        return input_value
+    else:
+        return ExcelError('#NUM!', '`excel cannot handle a non-numeric `%s`' % input_name)
+
+
 def is_number(s): # http://stackoverflow.com/questions/354038/how-do-i-check-if-a-string-is-a-number-float-in-python
     try:
         float(s)

--- a/koala/utils.py
+++ b/koala/utils.py
@@ -7,6 +7,7 @@ import numbers
 import re
 import datetime as dt
 from six import string_types
+from copy import deepcopy
 
 from openpyxl.compat import unicode
 
@@ -361,6 +362,25 @@ def is_not_number_input(input_value):
         return not all([is_number(i) for i in input_value])
     else:
         return not is_number(input_value)
+
+
+def flatten_list(nested_list):
+    """Flatten an arbitrarily nested list, without recursion (to avoid
+    stack overflows). Returns a new list, the original list is unchanged.
+    >> list(flatten_list([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]]))
+    [1, 2, 3, 4, 5]
+    >> list(flatten_list([[1, 2], 3]))
+    [1, 2, 3]
+    """
+    nested_list = deepcopy(nested_list)
+
+    while nested_list:
+        sublist = nested_list.pop(0)
+
+        if isinstance(sublist, list):
+            nested_list = sublist + nested_list
+        else:
+            yield sublist
 
 
 def numeric_error(input_value, input_name):

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -62,6 +62,9 @@ class Test_Choose(unittest.TestCase):
 
 
 class Test_Irr(unittest.TestCase):
+    def test_irr_errors(self):
+        self.assertIsInstance(irr([-100, 39, 59, 55, ExcelError('#NUM')], 0), ExcelError)
+
     def test_irr_basic(self):
         self.assertEqual(round(irr([-100, 39, 59, 55, 20], 0), 7), 0.2809484)
 
@@ -79,6 +82,18 @@ class Test_Xirr(unittest.TestCase):
     def test_xirr_basic(self):
         self.assertEqual(round(xirr([-100, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), 0.1981947)
         self.assertEqual(round(xirr([-130, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), -0.0743828)
+
+
+class Test_Npv(unittest.TestCase):
+    def test_npv_errors(self):
+        self.assertIsInstance(npv(0.06, [1, 2, ExcelError('#NUM')]), ExcelError)
+        self.assertIsInstance(npv(ExcelError('#NUM'), [1, 2, 3]), ExcelError)
+
+
+    def test_npv_basic(self):
+        self.assertEqual(round(npv(0.06, [1, 2, 3]), 7), 5.2422470)
+        self.assertEqual(round(npv(0.06, 1, 2, 3), 7), 5.2422470)
+        self.assertEqual(round(npv(0.06, 1), 7), 0.9433962)
 
 
 class Test_Offset(unittest.TestCase):

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -71,6 +71,11 @@ class Test_Irr(unittest.TestCase):
 
 
 class Test_Xirr(unittest.TestCase):
+    def test_xirr_errors(self):
+        self.assertIsInstance(xirr([-100, 30, 30, 30, ExcelError('#NUM')], [43571, 43721, 43871, 44021, 44171], 0), ExcelError)
+        self.assertIsInstance(xirr([-100, 30, 30, 30, 30], [43571, 43721, 43871, 44021, ExcelError('#NUM')], 0), ExcelError)
+
+
     def test_xirr_basic(self):
         self.assertEqual(round(xirr([-100, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), 0.1981947)
         self.assertEqual(round(xirr([-130, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), -0.0743828)


### PR DESCRIPTION
These functions would not give the right results if any input was ExcelError. This would lead to errors.