### PR TITLE
Speed improvements

### DIFF
--- a/koala/Range.py
+++ b/koala/Range.py
@@ -4,8 +4,6 @@ from koala.CellBase import CellBase
 from koala.ExcelError import ErrorCodes, ExcelError
 from koala.utils import *
 
-from functools import lru_cache
-
 from openpyxl.compat import unicode
 
 

--- a/koala/Range.py
+++ b/koala/Range.py
@@ -4,6 +4,8 @@ from koala.CellBase import CellBase
 from koala.ExcelError import ErrorCodes, ExcelError
 from koala.utils import *
 
+from functools import lru_cache
+
 from openpyxl.compat import unicode
 
 
@@ -250,10 +252,7 @@ class RangeCore(dict):
     @property
     def values(self):
         if self.__cellmap:
-            values = []
-            for cell in self.cells:
-                values.append(cell.value)
-            return values
+            return [cell.value for cell in self.cells]
         else:
             return self.cells
 

--- a/koala/utils.py
+++ b/koala/utils.py
@@ -6,8 +6,8 @@ import collections
 import numbers
 import re
 import datetime as dt
-from six import string_types
 from functools import lru_cache
+from six import string_types
 
 from openpyxl.compat import unicode
 

--- a/koala/utils.py
+++ b/koala/utils.py
@@ -6,7 +6,10 @@ import collections
 import numbers
 import re
 import datetime as dt
-from functools import lru_cache
+try:
+    from functools import lru_cache
+except ImportError:  # fix for Python 2.7
+    from backports.functools_lru_cache import lru_cache
 from six import string_types
 
 from openpyxl.compat import unicode

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ lxml==4.1.1
 six==1.11.0
 scipy>=1.0.0
 python-dateutil==2.8.0
+backports.functools_lru_cache==1.5


### PR DESCRIPTION
This commit drastically improves speed for large excels with many ranges of the style 1:1 or A:A.

It implements caching of some functions that are very frequently called but are actually quite expensive. An example is find_corresponding_index. When the inputs are the same (the value list) and the criterion is the same, logically it should return the same value.

The overhead of this caching is almost, but it can have a huge positive effect. For one of my larger test files, the calculation time went from 30s to less than 3s.