### PR TITLE
Fixes XIRR and EOMONTH

### DIFF
--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -698,7 +698,7 @@ class Spreadsheet(object):
                     if 'new' not in list(self.history[cell.address()].keys()):
                         if type(ori_value) == list and type(cell.value) == list \
                                 and all([not is_almost_equal(x_y[0], x_y[1]) for x_y in zip(ori_value, cell.value)]) \
-                            or not is_almost_equal(ori_value, cell.value):
+                                or not is_almost_equal(ori_value, cell.value):
 
                             self.count += 1
                             self.history[cell.address()]['formula'] = str(cell.formula)

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -983,6 +983,9 @@ def xirr(values, dates, guess=0):
     if isinstance(values, Range):
         values = values.values
 
+    if all(value < 0 for value in values):
+        return 0
+
     if isinstance(dates, Range):
         dates = dates.values
 
@@ -993,7 +996,7 @@ def xirr(values, dates, guess=0):
             try:
                 return scipy.optimize.newton(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), 0.0)
             except (RuntimeError, FloatingPointError, ExcelError):  # Failed to converge?
-                return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), -1.0, 1e10)
+                return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), -1.0, 1e5)
         except Exception:
             return ExcelError('#NUM', 'IRR did not converge.')
 

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -990,9 +990,12 @@ def xirr(values, dates, guess=0):
         raise ValueError('guess value for excellib.irr() is %s and not 0' % guess)
     else:
         try:
-            return scipy.optimize.newton(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), 0.0)
-        except (RuntimeError, FloatingPointError, ExcelError):  # Failed to converge?
-            return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), -1.0, 1e10)
+            try:
+                return scipy.optimize.newton(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), 0.0)
+            except (RuntimeError, FloatingPointError, ExcelError):  # Failed to converge?
+                return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), -1.0, 1e10)
+        except Exception:
+            return ExcelError('#NUM', 'IRR did not converge.')
 
 
 def vlookup(lookup_value, table_array, col_index_num, range_lookup = True): # https://support.office.com/en-us/article/VLOOKUP-function-0bbc8083-26fe-4963-8ab8-93a18ad188a1

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -990,9 +990,9 @@ def xirr(values, dates, guess=0):
         raise ValueError('guess value for excellib.irr() is %s and not 0' % guess)
     else:
         try:
-            return scipy.optimize.newton(lambda r: xnpv(r, values, dates, lim_rate=False), 0.0)
-        except RuntimeError:  # Failed to converge?
-            return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate=False), -1.0, 1e10)
+            return scipy.optimize.newton(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), 0.0)
+        except (RuntimeError, FloatingPointError):  # Failed to converge?
+            return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), -1.0, 1e10)
 
 
 def vlookup(lookup_value, table_array, col_index_num, range_lookup = True): # https://support.office.com/en-us/article/VLOOKUP-function-0bbc8083-26fe-4963-8ab8-93a18ad188a1
@@ -1128,13 +1128,15 @@ def vdb(cost, salvage, life, start_period, end_period, factor = 2, no_switch = F
     return result
 
 
-def xnpv(rate, values, dates, lim_rate = True):  # Excel reference: https://support.office.com/en-us/article/XNPV-function-1b42bbf6-370f-4532-a0eb-d67c16b664b7
+def xnpv(rate, values, dates, lim_rate_low=True, lim_rate_high=False):  # Excel reference: https://support.office.com/en-us/article/XNPV-function-1b42bbf6-370f-4532-a0eb-d67c16b664b7
     """
     Function to calculate the net present value (NPV) using payments and non-periodic dates. It resembles the excel function XPNV().
 
     :param rate: the discount rate.
     :param values: the payments of which at least one has to be negative.
     :param dates: the dates as excel dates (e.g. 43571 for 16/04/2019).
+    :param lim_rate_low: to limit the rate below 0.
+    :param lim_rate_high: to limit the rate above 1000 to avoid overflow errors.
     :return: a float being the NPV.
     """
     if isinstance(values, Range):
@@ -1146,10 +1148,14 @@ def xnpv(rate, values, dates, lim_rate = True):  # Excel reference: https://supp
     if len(values) != len(dates):
         return ExcelError('#NUM!', '`values` range must be the same length as `dates` range in XNPV, %s != %s' % (len(values), len(dates)))
 
-    if lim_rate and rate < 0:
+    if lim_rate_low and rate < 0:
         return ExcelError('#NUM!', '`excel cannot handle a negative `rate`' % (len(values), len(dates)))
 
+    if lim_rate_high and rate > 1000:
+        return ExcelError('#NUM!', '`will result in an overflow error due to high `rate`' % (len(values), len(dates)))
+
     xnpv = 0
+    np.seterr(all='raise')
     for v, d in zip(values, dates):
         xnpv += v / np.power(1.0 + rate, (d - dates[0]) / 365)
 

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -991,7 +991,7 @@ def xirr(values, dates, guess=0):
     else:
         try:
             return scipy.optimize.newton(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), 0.0)
-        except (RuntimeError, FloatingPointError):  # Failed to converge?
+        except (RuntimeError, FloatingPointError, ExcelError):  # Failed to converge?
             return scipy.optimize.brentq(lambda r: xnpv(r, values, dates, lim_rate_low=False, lim_rate_high=True), -1.0, 1e10)
 
 
@@ -1152,7 +1152,7 @@ def xnpv(rate, values, dates, lim_rate_low=True, lim_rate_high=False):  # Excel 
         return ExcelError('#NUM!', '`excel cannot handle a negative `rate`' % (len(values), len(dates)))
 
     if lim_rate_high and rate > 1000:
-        return ExcelError('#NUM!', '`will result in an overflow error due to high `rate`' % (len(values), len(dates)))
+        raise ExcelError('#NUM!', '`will result in an overflow error due to high `rate`')
 
     xnpv = 0
     np.seterr(all='raise')

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -528,7 +528,7 @@ def eomonth(start_date, months): # Excel reference: https://support.office.com/e
 
     y1, m1, d1 = date_from_int(start_date)
     start_date_d = datetime.date(year=y1, month=m1, day=d1)
-    end_date_d = start_date_d + relativedelta(months=months)
+    end_date_d = start_date_d + relativedelta(months=int(months))
     y2 = end_date_d.year
     m2 = end_date_d.month
     d2 = monthrange(y2, m2)[1]

--- a/koala/utils.py
+++ b/koala/utils.py
@@ -426,6 +426,8 @@ def date_from_int(nb):
     if not is_number(nb):
         raise TypeError("%s is not a number" % str(nb))
 
+    nb = int(nb)
+
     # origin of the Excel date system
     current_year = 1900
     current_month = 0
@@ -457,7 +459,6 @@ def int_from_date(date):
     return float(delta.days) + (float(delta.seconds) / 86400)
 
 def criteria_parser(criteria):
-
     if is_number(criteria):
         def check(x):
             try:

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -821,6 +821,8 @@ class Test_Eomonth(unittest.TestCase):
 
     def test_results(self):
         self.assertEqual(eomonth(43566, 2), 43646)  # 11/04/2019, add 2 months
+        self.assertEqual(eomonth(43566, 2.1), 43646)  # 11/04/2019, add 2 months
+        self.assertEqual(eomonth(43566, 2.99), 43646)  # 11/04/2019, add 2 months
         self.assertEqual(eomonth(43831, 5), 44012)  # 01/01/2020, add 5 months
         self.assertEqual(eomonth(36525, 1), 36556)  # 31/12/1999, add 1 month
         self.assertEqual(eomonth(36525, 15), 36981)  # 31/12/1999, add 15 month

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -75,13 +75,13 @@ class Test_Xirr(unittest.TestCase):
     def test_xirr_basic(self):
         self.assertEqual(round(xirr([-100, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), 0.1981947)
         self.assertEqual(round(xirr([-130, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), -0.0743828)
-        self.assertIsInstance(round(xirr(
+        self.assertIsInstance(xirr(
             [-0.01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1312.46, -565.86, -711.87, -1410.09, -1495.17, -2943.51, -1450.77,
              -783.22, -112.72, -137.33, 428.64, -1340.84, -256.75],
             [43646, 43830, 44012, 44196, 44377, 44561, 44742, 44926, 45107, 45291, 45473, 45657, 45838, 46022, 46203,
              46387, 46568, 46752, 46934, 47118, 47299, 47483, 47664, 47848, 48029],
             0),
-                                    7), ExcelError)  # under this example, Excel would actually return a wrong value
+                              ExcelError)  # under this example, Excel would actually return a wrong value
 
 
 class Test_Offset(unittest.TestCase):

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -75,6 +75,13 @@ class Test_Xirr(unittest.TestCase):
     def test_xirr_basic(self):
         self.assertEqual(round(xirr([-100, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), 0.1981947)
         self.assertEqual(round(xirr([-130, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0), 7), -0.0743828)
+        self.assertIsInstance(round(xirr(
+            [-0.01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1312.46, -565.86, -711.87, -1410.09, -1495.17, -2943.51, -1450.77,
+             -783.22, -112.72, -137.33, 428.64, -1340.84, -256.75],
+            [43646, 43830, 44012, 44196, 44377, 44561, 44742, 44926, 45107, 45291, 45473, 45657, 45838, 46022, 46203,
+             46387, 46568, 46752, 46934, 47118, 47299, 47483, 47664, 47848, 48029],
+            0),
+                                    7), ExcelError)  # under this example, Excel would actually return a wrong value
 
 
 class Test_Offset(unittest.TestCase):

--- a/workflow/xxx.py
+++ b/workflow/xxx.py
@@ -1,0 +1,3 @@
+from koala.excellib import xirr
+
+print(xirr([-100, 30, 30, 30, 30], [43571, 43721, 43871, 44021, 44171], 0))


### PR DESCRIPTION
EOMONTH can now work with non-integer values like in Excel.

XIRR now returns an error like in Excel when it cannot converge.
The NPV would return other values in excel under some edge cases. The IRR function would fail under some edge cases since it uses the NPV function.