### PR TITLE
Spreadsheets can be loaded from file-like objects and random functions

### DIFF
--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -50,9 +50,11 @@ class Spreadsheet(object):
         else:
             # fill in what the ExcelCompiler used to do
             super(Spreadsheet, self).__init__() # generate an empty spreadsheet
-            file_name = os.path.abspath(file)
             # Decompose subfiles structure in zip file
-            archive = read_archive(file_name)
+            if hasattr(file, 'read'):   # file-like object
+                archive = read_archive(file)
+            else:                       # assume file path
+                archive = read_archive(os.path.abspath(file))
             # Parse cells
             self.cells = read_cells(archive, ignore_sheets, ignore_hidden)
             # Parse named_range { name (ExampleName) -> address (Sheet!A1:A10)}

--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -1070,14 +1070,6 @@ class Spreadsheet(object):
     @staticmethod
     def from_dict(input_data):
 
-        def find_cell(nodes, address):
-            for node in nodes:
-                cell = node['id']
-                if cell.address() == address:
-                    return cell
-
-            assert False
-
         data = dict(input_data)
 
         nodes = list(
@@ -1100,12 +1092,13 @@ class Spreadsheet(object):
         data["nodes"] = [{'id': node} for node in nodes]
 
         links = []
+        idmap = { node.address(): node for node in nodes }
         for el in data['links']:
             source_address = el['source']
             target_address = el['target']
             link = {
-                'source': find_cell(data['nodes'], source_address),
-                'target': find_cell(data['nodes'], target_address)
+                'source': idmap[source_address],
+                'target': idmap[target_address],
             }
             links.append(link)
 

--- a/koala/excellib.py
+++ b/koala/excellib.py
@@ -12,6 +12,7 @@ import itertools
 import numpy as np
 import scipy.optimize
 import datetime
+import random
 from math import log, ceil
 from decimal import Decimal, ROUND_UP, ROUND_HALF_UP
 from calendar import monthrange
@@ -109,6 +110,8 @@ IND_FUN = [
     "YEAR",
     "MONTH",
     "EOMONTH",
+    "RANDBETWEEN",
+    "RAND",
 ]
 
 CELL_CHARACTER_LIMIT = 32767
@@ -1273,6 +1276,22 @@ def concatenate(*args):
         return ExcelError('#VALUE', 'Too long. concatentaed string should be no longer than %s but is %s' % (CELL_CHARACTER_LIMIT, len(cat_String)))
 
     return cat_string
+
+
+# https://support.office.com/en-us/article/randbetween-function-4cc7f0d1-87dc-4eb7-987f-a469ab381685
+def randbetween(bottom, top):
+    # instantiating a new random class so repeated calls don't share state
+    r = random.Random()
+    return r.randint(bottom, top)
+
+
+# https://support.office.com/en-us/article/rand-function-4cbfa695-8869-4788-8d90-021ea9f5be73
+def rand():
+    # instantiating a new random class so repeated calls don't share state
+    r = random.Random()
+    return r.random()
+
+
 
 if __name__ == '__main__':
     pass

--- a/koala/functions.json
+++ b/koala/functions.json
@@ -44,5 +44,7 @@
 "SLN",
 "XNPV",
 "PMT",
-"ROUNDUP"
+"ROUNDUP",
+"RANDBETWEEN",
+"RAND"
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     setup(
         name="koala2",
 
-        version="0.0.32",
+        version="0.0.34",
 
         author="Ants, open innovation lab",
         author_email="contact@weareants.fr",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     setup(
         name="koala2",
 
-        version="0.0.31",
+        version="0.0.32",
 
         author="Ants, open innovation lab",
         author_email="contact@weareants.fr",

--- a/tests/excel/test_functions.py
+++ b/tests/excel/test_functions.py
@@ -878,3 +878,28 @@ class Test_Eomonth(unittest.TestCase):
         self.assertEqual(eomonth(36525, 1), 36556)  # 31/12/1999, add 1 month
         self.assertEqual(eomonth(36525, 15), 36981)  # 31/12/1999, add 15 month
         self.assertNotEqual(eomonth(36525, 15), 36980)  # 31/12/1999, add 15 month
+
+
+class Test_Rand(unittest.TestCase):
+
+    def test_results(self):
+        # generate 10 random numbers
+        for i in range(10):
+            num = rand()
+            self.assertIsInstance(num, float)
+            self.assertGreaterEqual(num, 0.0)
+            self.assertLessEqual(num, 1.0)
+
+
+class Test_RandBetween(unittest.TestCase):
+
+    def test_results(self):
+        # a number between 0 and 10
+        num = randbetween(0, 10)
+        self.assertIsInstance(num, int)
+        self.assertGreaterEqual(num, 0)
+        self.assertLessEqual(num, 10)
+        # the number 1 every time
+        num = randbetween(1, 1)
+        self.assertIsInstance(num, int)
+        self.assertEqual(num, 1)

--- a/tests/excel/test_spreadsheet.py
+++ b/tests/excel/test_spreadsheet.py
@@ -1,3 +1,4 @@
+import io
 import sys
 import unittest
 
@@ -23,3 +24,18 @@ class Test_Spreadsheet(unittest.TestCase):
         self.assertEqual(spreadsheet.evaluate('Sheet1!A3'), 11)  # test function
         self.assertEqual(spreadsheet.evaluate('Sheet1!A4'), 11)  # test range
         self.assertEqual(spreadsheet.evaluate('Sheet1!A5'), 1)  # test short range
+
+
+    def test_load_filename(self):
+        file_name = os.path.abspath("./tests/excel/VDB.xlsx")
+        spreadsheet = Spreadsheet(file_name)
+        # really just testing the loading from "fin", but check one cell to be sure it read
+        self.assertEqual(spreadsheet.evaluate('Sheet1!A2'), "Init")
+
+
+    def test_load_stream(self):
+        file_name = os.path.abspath("./tests/excel/VDB.xlsx")
+        with open(file_name, 'rb') as fin:
+            spreadsheet = Spreadsheet(fin)
+        # really just testing the loading from "fin", but check one cell to be sure it read
+        self.assertEqual(spreadsheet.evaluate('Sheet1!A2'), "Init")

--- a/tests/excel/test_spreadsheet.py
+++ b/tests/excel/test_spreadsheet.py
@@ -39,3 +39,18 @@ class Test_Spreadsheet(unittest.TestCase):
             spreadsheet = Spreadsheet(fin)
         # really just testing the loading from "fin", but check one cell to be sure it read
         self.assertEqual(spreadsheet.evaluate('Sheet1!A2'), "Init")
+
+
+    def test_as_from_dict(self):
+        file_name = os.path.abspath("./tests/excel/VDB.xlsx")
+        sp1 = Spreadsheet(file_name)
+        sp1.cell_set_value('Sheet1!B7', value=100)
+        sp1.cell_set_value('Sheet1!B8', value=200)
+        # serialize to a dict, then back to a clone instance
+        data = sp1.asdict()
+        sp2 = Spreadsheet.from_dict(data)
+        # set values in the new spreadsheet - should be different than before
+        sp2.cell_set_value('Sheet1!B7', value=500)
+        sp2.cell_set_value('Sheet1!B8', value=600)
+        self.assertNotEqual(sp1.cell_evaluate('Sheet1!B7'), sp2.cell_evaluate('Sheet1!B7'))
+        self.assertNotEqual(sp1.cell_evaluate('Sheet1!B8'), sp2.cell_evaluate('Sheet1!B8'))


### PR DESCRIPTION
1. While openpyxl allows loading spreadsheets from both file paths (str) and file-like objects, koala only supported file paths. The Spreadsheet constructor now checks the `file` parameter for a `.read` attribute, and if it has this attribute, assumes it is an open stream to a file rather than the file path string.
2. Added Excel's two random (RAND and RANDBETWEEN) functions to the supported functions. Since python's random library is not thread-safe (threads would share the same seed), the code creates the random.Random() object directly so each call to the function has its own seed and is thread safe.

I also added two unit tests to test both ways of loading spreadsheets.