### PR TITLE
 Small refactor of `Spreadsheet.from_dict` to make it faster.

### DIFF
--- a/koala/Spreadsheet.py
+++ b/koala/Spreadsheet.py
@@ -1068,14 +1068,6 @@ class Spreadsheet(object):
     @staticmethod
     def from_dict(input_data):
 
-        def find_cell(nodes, address):
-            for node in nodes:
-                cell = node['id']
-                if cell.address() == address:
-                    return cell
-
-            assert False
-
         data = dict(input_data)
 
         nodes = list(
@@ -1098,12 +1090,13 @@ class Spreadsheet(object):
         data["nodes"] = [{'id': node} for node in nodes]
 
         links = []
+        idmap = { node.address(): node for node in nodes }
         for el in data['links']:
             source_address = el['source']
             target_address = el['target']
             link = {
-                'source': find_cell(data['nodes'], source_address),
-                'target': find_cell(data['nodes'], target_address)
+                'source': idmap[source_address],
+                'target': idmap[target_address],
             }
             links.append(link)
 

--- a/tests/excel/test_spreadsheet.py
+++ b/tests/excel/test_spreadsheet.py
@@ -23,3 +23,18 @@ class Test_Spreadsheet(unittest.TestCase):
         self.assertEqual(spreadsheet.evaluate('Sheet1!A3'), 11)  # test function
         self.assertEqual(spreadsheet.evaluate('Sheet1!A4'), 11)  # test range
         self.assertEqual(spreadsheet.evaluate('Sheet1!A5'), 1)  # test short range
+
+
+    def test_as_from_dict(self):
+        file_name = os.path.abspath("./tests/excel/VDB.xlsx")
+        sp1 = Spreadsheet(file_name)
+        sp1.cell_set_value('Sheet1!B7', value=100)
+        sp1.cell_set_value('Sheet1!B8', value=200)
+        # serialize to a dict, then back to a clone instance
+        data = sp1.asdict()
+        sp2 = Spreadsheet.from_dict(data)
+        # set values in the new spreadsheet - should be different than before
+        sp2.cell_set_value('Sheet1!B7', value=500)
+        sp2.cell_set_value('Sheet1!B8', value=600)
+        self.assertNotEqual(sp1.cell_evaluate('Sheet1!B7'), sp2.cell_evaluate('Sheet1!B7'))
+        self.assertNotEqual(sp1.cell_evaluate('Sheet1!B8'), sp2.cell_evaluate('Sheet1!B8'))


### PR DESCRIPTION
After profiling the code to see why `from_dict` was slow, it was obvious that
the inner function `find_cell` was the culprit. This refactor removes the
inner function and instead uses a temporary dictionary to make things fast.

The two profile outputs below show load time going from 2.42 -> .23 seconds.

```

Code used to test (this uses a fairly large, complex spreadsheet):
    from koala import Spreadsheet
    import cProfile, pstats
    pr = cProfile.Profile()
    file_name = '/Users/conan/Downloads/logicandreference-a9-Conan_Albrecht-1.xlsm'
    sp1 = Spreadsheet(file_name)
    data = sp1.asdict()
    pr.enable()
    for i in range(5):
        sp2 = Spreadsheet.from_dict(data)
    pr.disable()
    ps = pstats.Stats(pr).sort_stats('time')
    ps.print_stats(50)

Before the change:
         7158776 function calls (7158276 primitive calls) in 2.418 seconds

   Ordered by: internal time
   List reduced from 83 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     5520    1.408    0.000    2.202    0.000 /Users/conan/Documents/data/programming/koala/koala/Spreadsheet.py:1073(find_cell)
  6889145    0.797    0.000    0.797    0.000 /Users/conan/Documents/data/programming/koala/koala/Cell.py:172(address)
     2135    0.050    0.000    0.050    0.000 {built-in method builtins.compile}
    10975    0.047    0.000    0.067    0.000 /Users/conan/Documents/data/programming/koala/koala/Cell.py:21(__init__)

After the change:
         297041 function calls (296541 primitive calls) in 0.230 seconds

   Ordered by: internal time
   List reduced from 83 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10975    0.063    0.000    0.083    0.000 /Users/conan/Documents/data/programming/koala/koala/Cell.py:21(__init__)
     2135    0.041    0.000    0.041    0.000 {built-in method builtins.compile}
        5    0.024    0.005    0.053    0.011 /Users/conan/.pyenv/versions/me3.6/lib/python3.6/site-packages/networkx/readwrite/json_graph/node_link.py:104(node_link_graph)
```