### PR TITLE
Percentage token has .tvalue as float

### DIFF
--- a/koala/ast/astnodes.py
+++ b/koala/ast/astnodes.py
@@ -317,7 +317,7 @@ class FunctionNode(ASTNode):
             childs = args[0].children(ast)
 
             for child in childs:
-                if ':' in child.tvalue and child.tvalue != ':':
+                if ':' in str(child.tvalue) and child.tvalue != ':':
                     is_range = True
                     range = child.tvalue
                     break


### PR DESCRIPTION
- `str` was expected
- e.g. `=IF(RANGE>75%; 1; 0)` fails since `75%` is translated to `0.75`
- while `=IF(RANGE>.75; 1; 0)` would translate to `'0.75'`