### PR TITLE
add missing import into code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This operation may take some time depending on the size of your workbook (we've 
 
 ```
 from koala.ExcelCompiler import ExcelCompiler
+from koala.Spreadsheet import Spreadsheet
 
 sp = Spreadsheet("examples/basic.xlsx")
 ```


### PR DESCRIPTION
added this line to the example, for clarity:
`from koala.Spreadsheet import Spreadsheet`